### PR TITLE
[FIX] remote login: able to exchange auth code for access token 

### DIFF
--- a/srcs/django/ft_transcendence/accounts/templates/accounts/profile.html
+++ b/srcs/django/ft_transcendence/accounts/templates/accounts/profile.html
@@ -98,7 +98,7 @@
 										<!--/////////////////////////////////////////////-->
 										<button
 											data-next-url="{% url 'accounts:friend_request_cancel' %}"
-											onclick="sendFriendRequest('{{ id }}', {% if csrf_token %} '{{ csrf_token.value }}' {% else %} '{{ my_csrf }}' {%endif%})"
+											onclick="sendFriendRequest('{{ id }}', {% if csrf_token %} '{{ csrf_token }}' {% else %} '{{ my_csrf }}' {%endif%})"
 											class="btn_requests"
 											id="id_send_friend_request_btn">
 											Add Friend
@@ -199,7 +199,7 @@
 			<h5 class="mt-2">Friend Requests</h5>
 			<div
 				data-id="{{id}}"
-				{%if csrf_token %} data-csrf="{{ csrf_token.value }}" {%else%} data-csrf="{{ my_csrf }}" {%endif%}
+				{%if csrf_token %} data-csrf="{{ csrf_token }}" {%else%} data-csrf="{{ my_csrf }}" {%endif%}
 				id="widget_status_bar"
 			>
 			{% if request.user.is_authenticated and is_self == True%}

--- a/srcs/django/ft_transcendence/accounts/templates/accounts/profile.html
+++ b/srcs/django/ft_transcendence/accounts/templates/accounts/profile.html
@@ -75,7 +75,7 @@
 									)" 
 									id="id_cancel_request_btn"
 									class="btn_requests">
-									Invitation sent
+									Invitation Sent
 								</button>
 							{% endif %}
 							<!-- No requests has been sent -->

--- a/srcs/django/ft_transcendence/accounts/templates/accounts/widget.html
+++ b/srcs/django/ft_transcendence/accounts/templates/accounts/widget.html
@@ -6,7 +6,7 @@
 <div class="users_list" id="friends_cards">
     {% for f in friends %}
     <div class="user_card">
-        <a 
+        <a
             hx-get="/accounts/profile/{{ f.username }}"
             hx-target="#app-root"
             hx-push-url="true">

--- a/srcs/django/ft_transcendence/accounts/views.py
+++ b/srcs/django/ft_transcendence/accounts/views.py
@@ -353,7 +353,10 @@ def accept_friend_request(request, *args, **kwargs) -> HttpResponse:
                     friends = friend_list.friends.all()
                     context = {
                         'request': request,
-                        'friends': friends
+                        'friends': friends,
+                        'all_users': User.objects.all(),
+                        'blocklist': user.profile.blocklist.all(),
+                        'is_self': True,
                     }
                     payload['content'] = render_block_to_string('accounts/widget.html', 'content', context)
                 else:


### PR DESCRIPTION
Due to missing csrf token the remote login was not working, failing to exchnage the authorization code for the access token.

+ [FIX] profile: POST request on manual page reload leading to error. also related to missing csrf